### PR TITLE
NEW Allow all lists to inspect post-filtered list

### DIFF
--- a/code/filter/ListFilterSharedSolr.php
+++ b/code/filter/ListFilterSharedSolr.php
@@ -9,6 +9,12 @@ class ListFilterSharedSolr extends ListFilterShared {
 	 * @var SolrQueryBuilder
 	 */
 	protected $builder = null;
+    
+    /**
+     *
+     * @var SolrResultSet
+     */
+    protected $resultSet = null;
 
 	/**
 	 * @return SolrQueryBuilder
@@ -46,8 +52,8 @@ class ListFilterSharedSolr extends ListFilterShared {
 		 * @var $solr SolrSearchService
 		 */
 		$solr = singleton('SolrSearchService');
-		$solrResultSet = $solr->query($builder);
-		$solrResults = $solrResultSet->getResult();
+		$this->resultSet = $solr->query($builder);
+		$solrResults = $this->resultSet->getResult();
 		if (!isset($solrResults->response->docs)) {
 			$errorMessage = __CLASS__.': Missing "SolrResultSet::response->docs" from Solr. Has Solr been started?';
 			if (Director::isDev()) {
@@ -78,4 +84,12 @@ class ListFilterSharedSolr extends ListFilterShared {
 		}
 		return $list;
 	}
+    
+    /**
+     * 
+     * @return SolrResultSet
+     */
+    public function getResultSet() {
+        return $this->resultSet;
+    }
 }

--- a/code/form/ListFilterForm.php
+++ b/code/form/ListFilterForm.php
@@ -18,6 +18,13 @@ class ListFilterForm extends Form {
 	 * @var ListFilterSet
 	 */
 	protected $record = null;
+    
+    /**
+     * The current result set
+     *
+     * @var SS_List
+     */
+    protected $resultList = null;
 
 	/** 
 	 * @var ListFilterWidget
@@ -77,6 +84,8 @@ class ListFilterForm extends Form {
 				}
 			}
 		}
+        
+        $this->resultList = $this->record->PaginatedFilteredList($this->getVarData(), $this);
 	}
 
 	/**
@@ -233,7 +242,7 @@ class ListFilterForm extends Form {
 	 */
 	public function Listing(SS_List $list = null) {
 		if ($list === null) {
-			$list = $this->getRecord()->PaginatedFilteredList($this->getVarData(), $this);
+			$list = $this->resultList;
 		}
 		// todo(Jake): get class ancestry for rendering *_ListFilterListing
 		$result = $this->customise(array(
@@ -315,7 +324,7 @@ class ListFilterForm extends Form {
 	 * @return array
 	 */
 	public function doGetListing_Ajax($data) {
-		$list = $this->getRecord()->PaginatedFilteredList($data, $this);
+		$list = $this->resultList;
 		$template = $this->Listing($list);
 		$result = array();
 		$filterGroupData = $this->FilterBackendData($data);

--- a/code/model/ListFilterBase.php
+++ b/code/model/ListFilterBase.php
@@ -126,6 +126,13 @@ class ListFilterBase extends DataObject {
 	public function applyFilter(SS_List $list, array $data) {
 		throw new Exception('Missing "'.__FUNCTION__.'" implementation for "'.$this->class.'"');
 	}
+    
+    /**
+     * @param SS_List $list
+     */
+    public function finaliseFilter(SS_List $list) {
+        
+    }
 
 	/**
 	 * Return a ListFilterShared object to share between ListFilterBase objects.

--- a/code/model/ListFilterSet.php
+++ b/code/model/ListFilterSet.php
@@ -229,6 +229,11 @@ class ListFilterSet extends DataObject {
 				}
 			}
 		}
+        
+        // finally, allow the filters to analyse the final list
+        foreach ($this->owner->ListFiltersPersist() as $filterGroup) {
+            $filterGroup->finaliseFilter($list);
+        }
 
 		$this->setCaller(null);
 		return $list;

--- a/code/model/ListFilterSolrFacet.php
+++ b/code/model/ListFilterSolrFacet.php
@@ -1,0 +1,81 @@
+<?php
+
+if (!class_exists('SolrSearchService')) {
+	return;
+}
+
+class ListFilterSolrFacet extends ListFilterBase {
+    
+    private static $db = array(
+        'FacetOn'       => 'Varchar',
+    );
+    
+    protected $filterList;
+    
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getFilterFields() {
+        $fields = parent::getFilterFields();
+        
+		$sharedFilter = $this->SharedFilter('ListFilterSharedSolr');
+		$builder = $sharedFilter->getQueryBuilder();
+        
+        if (!$this->filterList) {
+            $this->filterList = CheckboxSetField::create('FacetValues', $this->Title);
+        }
+        
+        $fields->push($this->filterList);
+        
+		return $fields;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function applyFilter(SS_List $list, array $data) {
+        $sharedFilter = $this->SharedFilter('ListFilterSharedSolr');
+		$builder = $sharedFilter->getQueryBuilder();
+        if (strlen($this->FacetOn)) {
+            $builder->addFacetFields(array($this->FacetOn));
+        }
+
+		if (isset($data['FilterGroup']) && is_array($data['FilterGroup'])) {
+            $selected = array_keys($data['FilterGroup']);
+            $filter = $this->FacetOn .':"' . implode('" ' . $this->FacetOn .':"', $selected) . '"';
+            
+            $builder->addFilter($filter);
+		}
+		
+		return $sharedFilter;
+	}
+    
+    public function finaliseFilter(SS_List $list) {
+        $sharedFilter = $this->SharedFilter('ListFilterSharedSolr');
+        $result = $sharedFilter->getResultSet();
+        if ($result) {
+            $facets = $result->getFacets();
+            if (isset($facets[$this->FacetOn])) {
+                $source = array();
+                foreach ($facets[$this->FacetOn] as $facet) {
+                    $source[$facet->Name] = $facet->Name . ' (' . $facet->Count . ')';
+                }
+                $this->filterList->setSource($source);
+            }
+        }
+    }
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getFilterBackendData(SS_List $list, array $data) {
+        return null;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+//	public function getJavascriptCallback() {
+//		return 'ListFilterGroupIDs';
+//	}
+}


### PR DESCRIPTION
Perform an additional post-filter-application step on each of the list filters
to allow them to update state based on the 'new' state of affairs after all the
other filters have been applied.

Additionally, move the filtering mechanism to earlier in the request cycle,
_before_ the form is actually generated, to ensure that any filter state can
be reflected in the form UI
