### PR TITLE
FIX only add score for empty field options

### DIFF
--- a/code/model/ListFilterSolrSort.php
+++ b/code/model/ListFilterSolrSort.php
@@ -35,8 +35,9 @@ class ListFilterSolrSort extends ListFilterBase
         $fields = $this->SortFieldOptions->getValues();
         if (!$fields) {
             $fields = array();
+			$fields['score'] = 'Relevance';
         }
-        $fields['score'] = 'Relevance';
+        
         return $fields;
     }
     


### PR DESCRIPTION
"Score" / Relevance sort option should only be available for the 'default' scenario