### PR TITLE
FIX Ensure a base * match exists for Solr filters

### DIFF
--- a/code/filter/ListFilterSharedSolr.php
+++ b/code/filter/ListFilterSharedSolr.php
@@ -36,7 +36,7 @@ class ListFilterSharedSolr extends ListFilterShared {
 		 */
 		$solr = singleton('SolrSearchService');
 		$builder = $solr->getQueryBuilder();
-		return $this->builder = $builder;
+		return $this->builder = $builder->baseQuery('*');
 	}
 
 	/**


### PR DESCRIPTION
Later keyword entry can change it if desired, otherwise ensures a 'match all' default is performed