### PR TITLE
FIX Ensure 'split' sort is applied on default sort

### DIFF
--- a/code/model/ListFilterSolrSort.php
+++ b/code/model/ListFilterSolrSort.php
@@ -65,13 +65,13 @@ class ListFilterSolrSort extends ListFilterBase
         if (isset($data['SortBy'])) {
             $opts = $this->getFieldOptions();
             $by = isset($opts[$data['SortBy']]) ? $data['SortBy'] : $by;
-            
-            if (strpos($by, ',')) {
-                $bits = explode(',', $by);
-                $by = implode(' ' . $dir . ', ', $bits);
-            }
         }
-        
+
+        if (strpos($by, ',')) {
+            $bits = explode(',', $by);
+            $by = implode(' ' . $dir . ', ', $bits);
+        }
+
         $builder->sortBy($by, $dir);
 		return $sharedFilter;
 	}


### PR DESCRIPTION
Default sort wasn't being properly split so sorting was incorrect