### PR TITLE
Fixes for 3.1 compatibility

### DIFF
--- a/code/ListFilterUtility.php
+++ b/code/ListFilterUtility.php
@@ -93,8 +93,9 @@ class ListFilterUtility {
 					$list = new ArrayList($result);
 				} else {
 					$idsSQL = "(".implode(',', $ids).")";
-
-					list($parentClass, $componentClass, $myIDColumnName, $relationIDColumnName, $manyManyTable) = singleton($class)->manyManyComponent($relationName);
+					$classObj = singleton($class);
+					$manyManyInfo = $classObj->hasMethod('manyManyComponent') ? 'manyManyComponent' : 'many_many';
+					list($parentClass, $componentClass, $myIDColumnName, $relationIDColumnName, $manyManyTable) = $classObj->$manyManyInfo($relationName);
 					$list = $list->innerJoin($manyManyTable, "\"{$myIDColumnName}\" = \"$parentClass\".\"ID\" AND \"{$relationIDColumnName}\" IN {$idsSQL}");
 				}
 			break;

--- a/code/form/ListFilterForm.php
+++ b/code/form/ListFilterForm.php
@@ -393,7 +393,7 @@ class ListFilterForm extends Form {
 				}
 			}
 
-			$data['TotalCount'] = $list->TotalItems();
+			$data['TotalCount'] = $list->getTotalItems();
 			if ($start < $data['TotalCount']) {
 				$data['OffsetStart'] = $start + 1;
 				$data['ThisPage'] = $list->CurrentPage();


### PR DESCRIPTION
fix(ListFilterForm): use getTotalItems() instead of TotalItems() - for 3.1 compatibility
fix(ListFilterUtility): use many_many() if manyManyComponent() method doesn't exist - for 3.1 compatibility

These updates have been tested on 3.1.20 and 3.2.5 systems.

